### PR TITLE
feat: add i18n support — configurable review language and English-fir…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,87 @@
 # Iara - AI Code Reviewer 🧜‍♀️
 
-Iara é uma ferramenta de revisão de código automatizada, agnóstica a projetos e configurável, projetada para rodar em pipelines de CI/CD ou localmente via CLI. Ela utiliza a API OpenRouter para acessar diversos modelos de LLM (Llama 3, Gemini 2.0, etc.) gratuitamente ou em planos pagos.
+🇧🇷 [Leia em Português](README.pt-br.md)
 
-## 🚀 Funcionalidades
+Iara is an automated, project-agnostic, configurable code review tool designed to run in CI/CD pipelines or locally via CLI. It uses the OpenRouter API to access multiple LLM models (Llama 3, Gemini 2.0, etc.) for free or on paid plans.
 
-- **Agnóstica**: Configure o contexto do seu projeto (Tech Stack, Regras) via JSON.
-- **Multi-Modelo**: Suporte a múltiplos provedores via OpenRouter.
-- **Fallback Inteligente**: Tenta modelos gratuitos automaticamente se o preferido falhar.
-- **Rules-Based (Estático)**: Identifica padrões perigosos instantaneamente sem gastar tokens (ex: `GetComponent` em loops no Unity).
-- **LLM-Based (Inteligente)**: Usa IA para entender a lógica, segurança e contexto, indo além da sintaxe.
-- **GitHub + GitLab**: Integração nativa com ambas as plataformas, com comentários automáticos em PRs/MRs.
+## 🚀 Features
 
-## 🧠 Capacidades
+- **Agnostic**: Configure your project context (Tech Stack, Rules) via JSON.
+- **Multi-Model**: Support for multiple providers via OpenRouter.
+- **Smart Fallback**: Automatically tries free models if the preferred one fails.
+- **Rules-Based (Static)**: Identifies dangerous patterns instantly without spending tokens (e.g., `GetComponent` in loops in Unity).
+- **LLM-Based (Intelligent)**: Uses AI to understand logic, security, and context, going beyond syntax.
+- **GitHub + GitLab**: Native integration with both platforms, with automatic comments on PRs/MRs.
+- **Multi-Language Reviews**: Configure the output language — reviews can be written in English, Portuguese, Spanish, French, and more.
 
-A Iara combina diferentes tipos de análise para uma revisão completa:
+## 🧠 Capabilities
 
-| Tipo | O que faz? | A Iara cobre? | Como? |
+Iara combines different types of analysis for a complete review:
+
+| Type | What does it do? | Does Iara cover it? | How? |
 | :--- | :--- | :--- | :--- |
-| **Análise Estática** | Caça bugs lendo o código (rápido). | ✅ **Sim** | Via Extensões (Regex) e LLM. |
-| **Linting** | Corrige estilo e formatação. | ✅ **Sim** | LLM pode sugerir *Clean Code*. |
-| **SAST** | Caça falhas de segurança no código. | ✅ **Sim** | Foco primário na busca por vulnerabilidades. |
-| **Análise Dinâmica** | Caça bugs rodando o app (lento). | ❌ Não | Foco em CI/CD rápido (Code Review). |
+| **Static Analysis** | Finds bugs by reading code (fast). | ✅ **Yes** | Via Extensions (Regex) and LLM. |
+| **Linting** | Fixes style and formatting. | ✅ **Yes** | LLM can suggest *Clean Code*. |
+| **SAST** | Finds security flaws in code. | ✅ **Yes** | Primary focus on vulnerability detection. |
+| **Dynamic Analysis** | Finds bugs by running the app (slow). | ❌ No | Focus on fast CI/CD (Code Review). |
 
-### O que ela detecta?
+### What does it detect?
 
-1.  **Unity / Game Dev**:
-    - Uso de APIs lentas (`Find`, `GetComponent`) em loops críticos (`Update`).
-    - Alocação excessiva de memória (Garbage Collection).
-    - Excesso de logs (`Debug.Log`) em builds finais.
+1. **Unity / Game Dev**:
+   - Use of slow APIs (`Find`, `GetComponent`) in critical loops (`Update`).
+   - Excessive memory allocation (Garbage Collection).
+   - Excess logging (`Debug.Log`) in final builds.
 
-2.  **Segurança (Geral)**:
-    - Credenciais hardcoded (Senhas, API Keys).
-    - Vulnerabilidades de Injeção (SQL, Command).
-    - Falta de validação de inputs.
+2. **Security (General)**:
+   - Hardcoded credentials (Passwords, API Keys).
+   - Injection vulnerabilities (SQL, Command).
+   - Missing input validation.
 
-3.  **Qualidade de Código**:
-    - Lógica complexa ou confusa.
-    - Erros de tratamento de exceções.
-    - Sugestões de refatoração para legibilidade.
+3. **Code Quality**:
+   - Complex or confusing logic.
+   - Exception handling errors.
+   - Refactoring suggestions for readability.
 
 ---
 
-## 📦 Instalação e Setup
+## 📦 Installation and Setup
 
-### 1. Instalar
+### 1. Install
 
 ```bash
 pip install iara-reviewer
 ```
 
-### 2. Configurar (Setup Interativo)
+### 2. Configure (Interactive Setup)
 
 ```bash
 iara init
 ```
 
-O wizard vai guiar você em 3 passos:
+The wizard will guide you through 4 steps:
 
-- **API Key** — Pede sua chave OpenRouter (gratuita em [openrouter.ai/keys](https://openrouter.ai/keys)), valida e salva
-- **Projeto** — Nome, tech stack, descrição
-- **Preferências** — Áreas de foco (Security, Performance, etc.)
+- **API Key** — Asks for your OpenRouter key (free at [openrouter.ai/keys](https://openrouter.ai/keys)), validates and saves it
+- **Language** — Choose the review output language (en, pt-br, es, fr, etc.)
+- **Project** — Name, tech stack, description
+- **Preferences** — Focus areas (Security, Performance, etc.)
 
-Pronto! A API key fica salva em `~/.iara/config.json` e o projeto em `.iara.json`.
+Done! The API key is saved at `~/.iara/config.json` and project config at `.iara.json`.
 
-### 3. Usar
+### 3. Use
 
 ```bash
 git diff main | iara
 ```
 
-### Verificar autenticação
+### Check authentication
 
 ```bash
 iara auth status
 ```
 
-### Setup alternativo (sem wizard)
+### Alternative setup (without wizard)
 
-Se preferir configurar manualmente:
+If you prefer to configure manually:
 
 ```bash
 # Linux/Mac
@@ -87,9 +91,9 @@ export OPENROUTER_API_KEY="sk-or-..."
 $env:OPENROUTER_API_KEY="sk-or-..."
 ```
 
-A prioridade de resolução da API key é: variável de ambiente > config global (`~/.iara/config.json`).
+API key resolution priority: environment variable > global config (`~/.iara/config.json`).
 
-### Via clone (Desenvolvimento)
+### From source (Development)
 
 ```bash
 git clone https://github.com/felipefernandes/iara.git
@@ -99,15 +103,15 @@ pip install -e .
 
 ---
 
-## ⚙️ Configuração do Projeto
+## ⚙️ Project Configuration
 
-O `iara init` cria automaticamente o `.iara.json`. Você também pode criá-lo manualmente:
+`iara init` automatically creates `.iara.json`. You can also create it manually:
 
 ```json
 {
   "project": {
-    "name": "Meu Projeto",
-    "description": "Descrição do projeto.",
+    "name": "My Project",
+    "description": "Project description.",
     "tech_stack": ["Python"]
   },
   "review": {
@@ -117,15 +121,24 @@ O `iara init` cria automaticamente o `.iara.json`. Você também pode criá-lo m
   "model": {
     "preferred": "google/gemini-2.0-flash-exp:free",
     "fallback_enabled": true
-  }
+  },
+  "language": "en"
 }
 ```
 
-Exemplo pronto disponível em `iara-example.json`.
+The `language` field controls the review output language. Supported values: `en`, `pt-br`, `es`, `fr`, `de`, `ja`, `zh`, `ko`, `ru`, or any language the LLM understands.
+
+You can also override via environment variable:
+
+```bash
+export IARA_LANGUAGE="pt-br"
+```
+
+A ready-to-use example is available at `iara-example.json`.
 
 ---
 
-## 🏃 Como Usar
+## 🏃 How to Use
 
 ### Via Pipe (Git Diff)
 
@@ -133,20 +146,20 @@ Exemplo pronto disponível em `iara-example.json`.
 git diff main | iara
 ```
 
-### Via Variável de Ambiente
+### Via Environment Variable
 
 ```bash
 export PR_DIFF=$(git diff main)
 iara
 ```
 
-### Modo Scan (Análise Estática)
+### Scan Mode (Static Analysis)
 
 ```bash
-iara --scan ./caminho/do/projeto
+iara --scan ./path/to/project
 ```
 
-### Forçando um Modelo
+### Forcing a Model
 
 ```bash
 export IARA_MODEL="meta-llama/llama-3.2-3b-instruct:free"
@@ -155,20 +168,20 @@ git diff | iara
 
 ---
 
-## 🐙 Integração GitHub
+## 🐙 GitHub Integration
 
-Adicione a Iara ao seu repositório GitHub em **2 passos**:
+Add Iara to your GitHub repository in **2 steps**:
 
-### 1. Configurar o secret
+### 1. Configure the secret
 
-Vá em **Settings > Secrets and variables > Actions > New repository secret** e adicione:
+Go to **Settings > Secrets and variables > Actions > New repository secret** and add:
 
-- Nome: `OPENROUTER_API_KEY`
-- Valor: sua chave da API OpenRouter
+- Name: `OPENROUTER_API_KEY`
+- Value: your OpenRouter API key
 
-### 2. Criar o workflow
+### 2. Create the workflow
 
-Crie o arquivo `.github/workflows/iara-review.yml`:
+Create the file `.github/workflows/iara-review.yml`:
 
 ```yaml
 name: Iara Code Review
@@ -190,41 +203,42 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Iara Code Review
-        uses: felipefernandes/iara@v1
+        uses: felipefernandes/iara@main
         with:
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-A Iara vai automaticamente:
+Iara will automatically:
 
-- Revisar o diff do Pull Request
-- Postar um comentário com o resultado da review
+- Review the Pull Request diff
+- Post a comment with the review result
 
-### Opções adicionais
+### Additional options
 
 ```yaml
-- uses: felipefernandes/iara@v1
+- uses: felipefernandes/iara@main
   with:
     openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-    model: 'google/gemini-2.0-flash-exp:free'   # Forçar modelo
-    config_path: '.iara.json'                     # Caminho do config
-    post_comment: 'true'                          # Postar comentário (default: true)
+    model: 'google/gemini-2.0-flash-exp:free'   # Force model
+    config_path: '.iara.json'                     # Config path
+    post_comment: 'true'                          # Post comment (default: true)
+    language: 'pt-br'                             # Review language
 ```
 
 ---
 
-## 🦊 Integração GitLab
+## 🦊 GitLab Integration
 
-### 1. Configurar variáveis
+### 1. Configure variables
 
-Vá em **Settings > CI/CD > Variables** e adicione:
+Go to **Settings > CI/CD > Variables** and add:
 
-- `OPENROUTER_API_KEY`: Chave da API OpenRouter
-- `GITLAB_TOKEN`: Personal/Project Access Token com scope `api` (necessário para comentários no MR)
+- `OPENROUTER_API_KEY`: OpenRouter API key
+- `GITLAB_TOKEN`: Personal/Project Access Token with `api` scope (required for MR comments)
 
-### 2. Adicionar ao `.gitlab-ci.yml`
+### 2. Add to `.gitlab-ci.yml`
 
 ```yaml
 stages:
@@ -259,16 +273,16 @@ iara_code_review:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 ```
 
-A Iara vai automaticamente:
+Iara will automatically:
 
-- Revisar o diff do Merge Request
-- Postar um comentário com o resultado da review no MR
+- Review the Merge Request diff
+- Post a comment with the review result on the MR
 
-Um template completo está disponível em `gitlab-ci.yml`.
+A complete template is available at `gitlab-ci.yml`.
 
 ---
 
-## 🔧 Qualquer CI (Jenkins, CircleCI, etc.)
+## 🔧 Any CI (Jenkins, CircleCI, etc.)
 
 ```bash
 pip install iara-reviewer
@@ -278,12 +292,12 @@ git diff main...HEAD | iara
 
 ---
 
-## 🧪 Testes
+## 🧪 Tests
 
 ```bash
 python -m unittest discover tests
 ```
 
-## 📜 Licença
+## 📜 License
 
 MIT

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,303 @@
+# Iara - AI Code Reviewer 🧜‍♀️
+
+🇺🇸 [Read in English](README.md)
+
+Iara é uma ferramenta de revisão de código automatizada, agnóstica a projetos e configurável, projetada para rodar em pipelines de CI/CD ou localmente via CLI. Ela utiliza a API OpenRouter para acessar diversos modelos de LLM (Llama 3, Gemini 2.0, etc.) gratuitamente ou em planos pagos.
+
+## 🚀 Funcionalidades
+
+- **Agnóstica**: Configure o contexto do seu projeto (Tech Stack, Regras) via JSON.
+- **Multi-Modelo**: Suporte a múltiplos provedores via OpenRouter.
+- **Fallback Inteligente**: Tenta modelos gratuitos automaticamente se o preferido falhar.
+- **Rules-Based (Estático)**: Identifica padrões perigosos instantaneamente sem gastar tokens (ex: `GetComponent` em loops no Unity).
+- **LLM-Based (Inteligente)**: Usa IA para entender a lógica, segurança e contexto, indo além da sintaxe.
+- **GitHub + GitLab**: Integração nativa com ambas as plataformas, com comentários automáticos em PRs/MRs.
+- **Reviews Multi-Idioma**: Configure o idioma de saída — reviews podem ser escritas em Português, Inglês, Espanhol, Francês e mais.
+
+## 🧠 Capacidades
+
+A Iara combina diferentes tipos de análise para uma revisão completa:
+
+| Tipo | O que faz? | A Iara cobre? | Como? |
+| :--- | :--- | :--- | :--- |
+| **Análise Estática** | Caça bugs lendo o código (rápido). | ✅ **Sim** | Via Extensões (Regex) e LLM. |
+| **Linting** | Corrige estilo e formatação. | ✅ **Sim** | LLM pode sugerir *Clean Code*. |
+| **SAST** | Caça falhas de segurança no código. | ✅ **Sim** | Foco primário na busca por vulnerabilidades. |
+| **Análise Dinâmica** | Caça bugs rodando o app (lento). | ❌ Não | Foco em CI/CD rápido (Code Review). |
+
+### O que ela detecta?
+
+1. **Unity / Game Dev**:
+   - Uso de APIs lentas (`Find`, `GetComponent`) em loops críticos (`Update`).
+   - Alocação excessiva de memória (Garbage Collection).
+   - Excesso de logs (`Debug.Log`) em builds finais.
+
+2. **Segurança (Geral)**:
+   - Credenciais hardcoded (Senhas, API Keys).
+   - Vulnerabilidades de Injeção (SQL, Command).
+   - Falta de validação de inputs.
+
+3. **Qualidade de Código**:
+   - Lógica complexa ou confusa.
+   - Erros de tratamento de exceções.
+   - Sugestões de refatoração para legibilidade.
+
+---
+
+## 📦 Instalação e Setup
+
+### 1. Instalar
+
+```bash
+pip install iara-reviewer
+```
+
+### 2. Configurar (Setup Interativo)
+
+```bash
+iara init
+```
+
+O wizard vai guiar você em 4 passos:
+
+- **API Key** — Pede sua chave OpenRouter (gratuita em [openrouter.ai/keys](https://openrouter.ai/keys)), valida e salva
+- **Idioma** — Escolha o idioma das reviews (en, pt-br, es, fr, etc.)
+- **Projeto** — Nome, tech stack, descrição
+- **Preferências** — Áreas de foco (Security, Performance, etc.)
+
+Pronto! A API key fica salva em `~/.iara/config.json` e o projeto em `.iara.json`.
+
+### 3. Usar
+
+```bash
+git diff main | iara
+```
+
+### Verificar autenticação
+
+```bash
+iara auth status
+```
+
+### Setup alternativo (sem wizard)
+
+Se preferir configurar manualmente:
+
+```bash
+# Linux/Mac
+export OPENROUTER_API_KEY="sk-or-..."
+
+# Windows (PowerShell)
+$env:OPENROUTER_API_KEY="sk-or-..."
+```
+
+A prioridade de resolução da API key é: variável de ambiente > config global (`~/.iara/config.json`).
+
+### Via clone (Desenvolvimento)
+
+```bash
+git clone https://github.com/felipefernandes/iara.git
+cd iara
+pip install -e .
+```
+
+---
+
+## ⚙️ Configuração do Projeto
+
+O `iara init` cria automaticamente o `.iara.json`. Você também pode criá-lo manualmente:
+
+```json
+{
+  "project": {
+    "name": "Meu Projeto",
+    "description": "Descrição do projeto.",
+    "tech_stack": ["Python"]
+  },
+  "review": {
+    "focus_areas": ["Performance", "Security"],
+    "ignore_patterns": []
+  },
+  "model": {
+    "preferred": "google/gemini-2.0-flash-exp:free",
+    "fallback_enabled": true
+  },
+  "language": "pt-br"
+}
+```
+
+O campo `language` controla o idioma das reviews. Valores suportados: `en`, `pt-br`, `es`, `fr`, `de`, `ja`, `zh`, `ko`, `ru`, ou qualquer idioma que o LLM entenda.
+
+Você também pode sobrescrever via variável de ambiente:
+
+```bash
+export IARA_LANGUAGE="pt-br"
+```
+
+Exemplo pronto disponível em `iara-example.json`.
+
+---
+
+## 🏃 Como Usar
+
+### Via Pipe (Git Diff)
+
+```bash
+git diff main | iara
+```
+
+### Via Variável de Ambiente
+
+```bash
+export PR_DIFF=$(git diff main)
+iara
+```
+
+### Modo Scan (Análise Estática)
+
+```bash
+iara --scan ./caminho/do/projeto
+```
+
+### Forçando um Modelo
+
+```bash
+export IARA_MODEL="meta-llama/llama-3.2-3b-instruct:free"
+git diff | iara
+```
+
+---
+
+## 🐙 Integração GitHub
+
+Adicione a Iara ao seu repositório GitHub em **2 passos**:
+
+### 1. Configurar o secret
+
+Vá em **Settings > Secrets and variables > Actions > New repository secret** e adicione:
+
+- Nome: `OPENROUTER_API_KEY`
+- Valor: sua chave da API OpenRouter
+
+### 2. Criar o workflow
+
+Crie o arquivo `.github/workflows/iara-review.yml`:
+
+```yaml
+name: Iara Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    name: AI Code Review
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Iara Code Review
+        uses: felipefernandes/iara@main
+        with:
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+A Iara vai automaticamente:
+
+- Revisar o diff do Pull Request
+- Postar um comentário com o resultado da review
+
+### Opções adicionais
+
+```yaml
+- uses: felipefernandes/iara@main
+  with:
+    openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+    model: 'google/gemini-2.0-flash-exp:free'   # Forçar modelo
+    config_path: '.iara.json'                     # Caminho do config
+    post_comment: 'true'                          # Postar comentário (default: true)
+    language: 'pt-br'                             # Idioma da review
+```
+
+---
+
+## 🦊 Integração GitLab
+
+### 1. Configurar variáveis
+
+Vá em **Settings > CI/CD > Variables** e adicione:
+
+- `OPENROUTER_API_KEY`: Chave da API OpenRouter
+- `GITLAB_TOKEN`: Personal/Project Access Token com scope `api` (necessário para comentários no MR)
+
+### 2. Adicionar ao `.gitlab-ci.yml`
+
+```yaml
+stages:
+  - review
+
+iara_code_review:
+  stage: review
+  image: python:3.11-slim
+  script:
+    - apt-get update && apt-get install -y --no-install-recommends git curl
+    - pip install iara-reviewer
+    - git fetch origin $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+    - export PR_DIFF=$(git diff origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME...$CI_COMMIT_SHA)
+    - REVIEW=$(iara 2>/tmp/iara_stderr.txt) || true
+    - echo "$REVIEW"
+    - |
+      if [ -n "$REVIEW" ] && [ -n "$GITLAB_TOKEN" ]; then
+        PAYLOAD=$(python3 -c "
+      import sys, json
+      review = '''$REVIEW'''
+      body = '## 🧜‍♀️ Iara Code Review\n\n' + review + '\n\n---\n*Reviewed by Iara - AI Code Reviewer*'
+      print(json.dumps({'body': body}))
+      ")
+        curl -s -X POST \
+          -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD" \
+          "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes"
+      fi
+  allow_failure: true
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+A Iara vai automaticamente:
+
+- Revisar o diff do Merge Request
+- Postar um comentário com o resultado da review no MR
+
+Um template completo está disponível em `gitlab-ci.yml`.
+
+---
+
+## 🔧 Qualquer CI (Jenkins, CircleCI, etc.)
+
+```bash
+pip install iara-reviewer
+export OPENROUTER_API_KEY="sk-or-..."
+git diff main...HEAD | iara
+```
+
+---
+
+## 🧪 Testes
+
+```bash
+python -m unittest discover tests
+```
+
+## 📜 Licença
+
+MIT

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Whether to post review as PR comment (true/false)'
     required: false
     default: 'true'
+  language:
+    description: 'Review output language (en, pt-br, es, fr, etc.). Defaults to config file or en.'
+    required: false
+    default: ''
 
 outputs:
   review:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ set -e
 # --- Input Variables (from action.yml inputs) ---
 OPENROUTER_API_KEY="${INPUT_OPENROUTER_API_KEY}"
 IARA_MODEL="${INPUT_MODEL}"
+IARA_LANGUAGE="${INPUT_LANGUAGE}"
 CONFIG_PATH="${INPUT_CONFIG_PATH:-.iara.json}"
 POST_COMMENT="${INPUT_POST_COMMENT:-true}"
 
@@ -51,6 +52,10 @@ export PR_DIFF="$DIFF"
 
 if [ -n "$IARA_MODEL" ]; then
   export IARA_MODEL
+fi
+
+if [ -n "$IARA_LANGUAGE" ]; then
+  export IARA_LANGUAGE
 fi
 
 # --- Copy config from workspace if it exists ---

--- a/iara-example.json
+++ b/iara-example.json
@@ -1,7 +1,7 @@
 {
   "project": {
-    "name": "Meu Projeto Incrível",
-    "description": "Uma API RESTful feita com FastAPI e PostgreSQL.",
+    "name": "My Awesome Project",
+    "description": "A RESTful API built with FastAPI and PostgreSQL.",
     "tech_stack": ["Python", "FastAPI", "PostgreSQL", "Docker"]
   },
   "review": {
@@ -11,5 +11,6 @@
   "model": {
     "preferred": "google/gemini-2.0-flash-exp:free",
     "fallback_enabled": true
-  }
+  },
+  "language": "en"
 }

--- a/iara/cli.py
+++ b/iara/cli.py
@@ -1,4 +1,4 @@
-"""Interface de linha de comando da Iara."""
+"""Command-line interface for Iara."""
 
 import os
 import sys
@@ -11,32 +11,32 @@ from iara.auth import resolve_api_key
 
 
 def main():
-    """Ponto de entrada principal."""
+    """Main entry point."""
     parser = argparse.ArgumentParser(
         description="Iara - AI Code Reviewer",
         usage="iara [command] [options]"
     )
 
-    # Argumentos top-level (retrocompatibilidade)
-    parser.add_argument("--scan", help="Diretório para escanear (Modo Scan)", default=None)
-    parser.add_argument("--diff", help="Arquivo de diff (opcional, lê de stdin por padrão)", default=None)
+    # Top-level arguments (backward compatibility)
+    parser.add_argument("--scan", help="Directory to scan (Scan Mode)", default=None)
+    parser.add_argument("--diff", help="Diff file (optional, reads from stdin by default)", default=None)
 
-    # Subcomandos
+    # Subcommands
     subparsers = parser.add_subparsers(dest="command")
     subparsers.required = False
 
     # iara init
-    subparsers.add_parser("init", help="Setup interativo (API key + config do projeto)")
+    subparsers.add_parser("init", help="Interactive setup (API key + project config)")
 
     # iara auth
-    auth_parser = subparsers.add_parser("auth", help="Gerenciamento de autenticacao")
+    auth_parser = subparsers.add_parser("auth", help="Authentication management")
     auth_sub = auth_parser.add_subparsers(dest="auth_command")
     auth_sub.required = False
-    auth_sub.add_parser("status", help="Verificar status da autenticacao")
+    auth_sub.add_parser("status", help="Check authentication status")
 
     args = parser.parse_args()
 
-    # --- Roteamento de subcomandos ---
+    # --- Subcommand routing ---
     if args.command == "init":
         from iara.init import run_init
         run_init()
@@ -51,28 +51,33 @@ def main():
             auth_parser.print_help()
             return
 
-    # --- Fluxo existente de review (sem subcomando) ---
+    # --- Existing review flow (no subcommand) ---
     api_key, source = resolve_api_key()
     if not api_key:
-        print("❌ Erro: API key não configurada.", file=sys.stderr)
-        print("Execute 'iara init' para configurar, ou defina OPENROUTER_API_KEY.", file=sys.stderr)
+        print("❌ Error: API key not configured.", file=sys.stderr)
+        print("Run 'iara init' to set up, or set OPENROUTER_API_KEY.", file=sys.stderr)
         sys.exit(1)
 
-    # Carrega configuracoes
+    # Load config
     config = load_config()
 
-    # Modo Scan
+    # Override language from env var if set
+    env_lang = os.environ.get("IARA_LANGUAGE")
+    if env_lang:
+        config["language"] = env_lang
+
+    # Scan Mode
     if args.scan:
         if not os.path.isdir(args.scan):
-             print("❌ Erro: Diretório '%s' não encontrado." % args.scan, file=sys.stderr)
+             print("❌ Error: Directory '%s' not found." % args.scan, file=sys.stderr)
              sys.exit(1)
 
-        print("🚀 Iniciando modo SCAN em: %s" % args.scan, file=sys.stderr)
+        print("🚀 Starting SCAN mode on: %s" % args.scan, file=sys.stderr)
         result = scan_directory(args.scan, config)
         print(result)
         return
 
-    # Modo Diff (Legacy/Default)
+    # Diff Mode (Legacy/Default)
     diff = os.environ.get("PR_DIFF", "")
     if args.diff:
          if os.path.exists(args.diff):
@@ -87,8 +92,8 @@ def main():
             diff = sys.stdin.read()
 
     if not diff:
-        print("ℹ️ Nenhuma entrada de código detectada (stdin vazio, sem PR_DIFF, sem --scan).", file=sys.stderr)
-        print("Use: `git diff | iara` ou `iara --scan <dir>` ou `iara init`", file=sys.stderr)
+        print("ℹ️ No code input detected (empty stdin, no PR_DIFF, no --scan).", file=sys.stderr)
+        print("Use: `git diff | iara` or `iara --scan <dir>` or `iara init`", file=sys.stderr)
         sys.exit(0)
 
     review = review_code(diff, api_key, config)

--- a/iara/config.py
+++ b/iara/config.py
@@ -7,8 +7,8 @@ import json
 # Configuracao Padrao (Generica)
 DEFAULT_CONFIG = {
     "project": {
-        "name": "Projeto Genérico",
-        "description": "Um projeto de software.",
+        "name": "Generic Project",
+        "description": "A software project.",
         "tech_stack": ["Python"]
     },
     "review": {
@@ -18,7 +18,8 @@ DEFAULT_CONFIG = {
     "model": {
         "preferred": None,
         "fallback_enabled": True
-    }
+    },
+    "language": "en"
 }
 
 def deep_merge(base, override):
@@ -42,7 +43,7 @@ def load_config(config_path=".iara.json"):
             user_config = json.load(f)
             return deep_merge(DEFAULT_CONFIG, user_config)
     except json.JSONDecodeError:
-        print("⚠️ Erro ao ler %s. Usando configuração padrão." % config_path, file=sys.stderr)
+        print("⚠️ Error reading %s. Using default config." % config_path, file=sys.stderr)
         return DEFAULT_CONFIG.copy()
 
 

--- a/iara/init.py
+++ b/iara/init.py
@@ -7,6 +7,7 @@ import getpass
 
 from iara.auth import validate_api_key, save_global_config, resolve_api_key
 from iara.config import DEFAULT_CONFIG, save_config
+from iara.prompt import LANGUAGE_MAP
 
 
 KNOWN_STACKS = ["Python", "C#", "Unity", "JavaScript", "TypeScript",
@@ -14,6 +15,8 @@ KNOWN_STACKS = ["Python", "C#", "Unity", "JavaScript", "TypeScript",
 
 KNOWN_FOCUS_AREAS = ["Logic", "Security", "Performance", "Clean Code",
                      "Error Handling", "Testing"]
+
+SUGGESTED_LANGUAGES = ["en", "pt-br", "es", "fr", "de", "ja", "zh"]
 
 
 def run_init():
@@ -25,14 +28,17 @@ def run_init():
     # --- Step 1: API Key ---
     api_key = _step_api_key()
 
-    # --- Step 2: Project Config ---
+    # --- Step 2: Language ---
+    language = _step_language()
+
+    # --- Step 3: Project Config ---
     project_config = _step_project_config()
 
-    # --- Step 3: Review Preferences ---
+    # --- Step 4: Review Preferences ---
     review_config = _step_review_config()
 
     # --- Save ---
-    _save_configs(api_key, project_config, review_config)
+    _save_configs(api_key, language, project_config, review_config)
 
     # --- Next steps ---
     _show_next_steps()
@@ -82,10 +88,22 @@ def _step_api_key():
                 return api_key
 
 
+def _step_language():
+    """Select review output language."""
+    print()
+    print("  Step 2: Review Language")
+    print()
+
+    lang_display = ", ".join("%s (%s)" % (code, LANGUAGE_MAP.get(code, code)) for code in SUGGESTED_LANGUAGES)
+    print("  Options: %s" % lang_display)
+    lang_input = input("  Review language [en]: ").strip().lower()
+    return lang_input if lang_input else "en"
+
+
 def _step_project_config():
     """Solicita configuracao do projeto."""
     print()
-    print("  Step 2: Project Configuration")
+    print("  Step 3: Project Configuration")
     print()
 
     default_name = os.path.basename(os.getcwd())
@@ -108,7 +126,7 @@ def _step_project_config():
 def _step_review_config():
     """Solicita preferencias de review."""
     print()
-    print("  Step 3: Review Preferences")
+    print("  Step 4: Review Preferences")
     print()
 
     print("  Available: %s, All" % ", ".join(KNOWN_FOCUS_AREAS))
@@ -127,7 +145,7 @@ def _step_review_config():
     }
 
 
-def _save_configs(api_key, project, review):
+def _save_configs(api_key, language, project, review):
     """Salva configs local e global."""
     print()
 
@@ -138,7 +156,8 @@ def _save_configs(api_key, project, review):
         "model": {
             "preferred": None,
             "fallback_enabled": True
-        }
+        },
+        "language": language
     }
 
     config_path = os.path.join(os.getcwd(), ".iara.json")

--- a/iara/prompt.py
+++ b/iara/prompt.py
@@ -1,59 +1,81 @@
-"""Geracao dinamica de system prompts."""
+"""Dynamic system prompt generation."""
+
+
+LANGUAGE_MAP = {
+    "en": "English",
+    "pt-br": "Brazilian Portuguese",
+    "pt": "Portuguese",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "it": "Italian",
+    "ja": "Japanese",
+    "zh": "Chinese",
+    "ko": "Korean",
+    "ru": "Russian",
+}
 
 
 def generate_system_prompt(config: dict) -> str:
-    """Gera o prompt do sistema dinamicamente com base na configuracao."""
+    """Generate the system prompt dynamically based on configuration."""
     project = config.get("project", {})
-    name = project.get("name", "Projeto Desconhecido")
-    desc = project.get("description", "Sem descrição.")
+    name = project.get("name", "Unknown Project")
+    desc = project.get("description", "No description.")
     stack = project.get("tech_stack", [])
 
-    # Construcao das regras especificas por stack
+    # Stack-specific rules
     stack_rules = ""
     if "Unity" in stack or "C#" in stack:
-        stack_rules += "- **Unity/C#**: Evite `GetComponent` em `Update`. Use `StringBuilder` para strings. Cuidado com Garbage Collection.\n"
+        stack_rules += "- **Unity/C#**: Avoid `GetComponent` in `Update`. Use `StringBuilder` for strings. Watch out for Garbage Collection.\n"
     if "Python" in stack:
-        stack_rules += "- **Python**: Siga PEP 8. Use `with` para lidar com arquivos. Evite imports circulares.\n"
+        stack_rules += "- **Python**: Follow PEP 8. Use `with` for file handling. Avoid circular imports.\n"
     if "Raspberry Pi" in stack:
-        stack_rules += "- **IoT/Raspberry Pi**: Otimize para hardware limitado (1GB RAM). Evite dependências pesadas.\n"
+        stack_rules += "- **IoT/Raspberry Pi**: Optimize for limited hardware (1GB RAM). Avoid heavy dependencies.\n"
 
-    return f"""Você é Iara, a revisora de código oficial do projeto **{name}**.
-Sua missão é revisar código focando em **Lógica, Segurança e Performance**.
+    # Language instruction
+    lang_code = config.get("language", "en")
+    lang_name = LANGUAGE_MAP.get(lang_code, lang_code)
 
-## CONTEXTO DO PROJETO:
+    return f"""You are Iara, the official code reviewer for the **{name}** project.
+Your mission is to review code focusing on **Logic, Security, and Performance**.
+
+## PROJECT CONTEXT:
 {desc}
 
-## TECNOLOGIAS E REGRAS:
+## TECHNOLOGIES AND RULES:
 Stack: {', '.join(stack)}
 {stack_rules}
 
-## CHECKLIST DE REVISÃO:
+## REVIEW CHECKLIST:
 
-### 🐛 BUGS REAIS (Foco Principal)
-- Erros de lógica (ex: contas erradas, condições inatingíveis).
-- Tratamento de exceções ausente.
-- Deadlocks ou loops infinitos.
+### 🐛 REAL BUGS (Primary Focus)
+- Logic errors (e.g., wrong calculations, unreachable conditions).
+- Missing exception handling.
+- Deadlocks or infinite loops.
 
-### 🔒 SEGURANÇA
-- Secrets hardcoded.
+### 🔒 SECURITY
+- Hardcoded secrets.
 - Injection flaws (SQL, Command).
-- Validação de entrada de usuário ausente.
+- Missing user input validation.
 
 ### ⚡ PERFORMANCE
-- Loops ineficientes.
-- Queries N+1.
-- Uso excessivo de memória.
+- Inefficient loops.
+- N+1 queries.
+- Excessive memory usage.
 
-### ❌ O QUE IGNORAR (Falsos Positivos):
-- Não reclame de estilo se não afetar a legibilidade gravemente.
-- Não reclame de variáveis globais se forem convenção do projeto (ex: configs).
+### ❌ WHAT TO IGNORE (False Positives):
+- Don't complain about style unless it seriously hurts readability.
+- Don't complain about global variables if they are project convention (e.g., configs).
 
-## FORMATO DA RESPOSTA:
-Seja direta e objetiva. Use emojis para categorizar.
-- 🐛 **Bug**: Problema lógico.
-- 🔒 **Segurança**: Risco de segurança.
-- ⚡ **Performance**: Ineficiência.
-- 🧹 **Clean Code**: Sugestão de legibilidade (opcional).
+## RESPONSE FORMAT:
+Be direct and objective. Use emojis to categorize.
+- 🐛 **Bug**: Logic issue.
+- 🔒 **Security**: Security risk.
+- ⚡ **Performance**: Inefficiency.
+- 🧹 **Clean Code**: Readability suggestion (optional).
 
-✅ **Se estiver tudo ok**: "✅ **Aprovação Iara**: Código robusto e alinhado ao projeto {name}. Pode mergear! 🧜‍♀️✨"
+✅ **If everything looks good**: "✅ **Iara Approved**: Robust code aligned with the {name} project. Ship it! 🧜‍♀️✨"
+
+## RESPONSE LANGUAGE:
+You MUST write your entire review in **{lang_name}**.
 """

--- a/iara/reviewer.py
+++ b/iara/reviewer.py
@@ -1,4 +1,4 @@
-"""Logica principal de revisao de codigo com integracao LLM."""
+"""Core code review logic with LLM integration."""
 
 import os
 import sys
@@ -13,17 +13,16 @@ from iara.prompt import generate_system_prompt
 
 
 def review_code_with_model(diff: str, api_key: str, model: str, system_prompt: str) -> str:
-    """Tenta revisar com um modelo especifico."""
+    """Try to review code with a specific model."""
     max_chars = 15000
     if len(diff) > max_chars:
-        diff = diff[:max_chars] + "\n\n[... diff truncado por limite de tamanho ...]"
+        diff = diff[:max_chars] + "\n\n[... diff truncated due to size limit ...]"
 
-    # Payload simplificado
     payload = {
         "model": model,
         "messages": [
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": f"Revise o seguinte diff de código:\n\n```diff\n{diff}\n```"}
+            {"role": "user", "content": f"Review the following code diff:\n\n```diff\n{diff}\n```"}
         ],
         "temperature": 0.3,
         "max_tokens": 6000,
@@ -52,11 +51,11 @@ def review_code_with_model(diff: str, api_key: str, model: str, system_prompt: s
                 content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
 
                 if not content:
-                    raise ValueError("Modelo retornou conteúdo vazio (ou apenas tags <think>).")
+                    raise ValueError("Model returned empty content (or only <think> tags).")
 
                 return content
             else:
-                raise ValueError("API retornou sucesso mas sem 'choices'.")
+                raise ValueError("API returned success but no 'choices'.")
 
     except urllib.error.HTTPError as e:
         error_body = e.read().decode("utf-8")
@@ -64,15 +63,13 @@ def review_code_with_model(diff: str, api_key: str, model: str, system_prompt: s
 
 
 def review_code(diff: str, api_key: str, config: dict) -> str:
-    """
-    Executa a revisao de codigo tentando o modelo configurado ou fallback.
-    """
+    """Execute code review trying configured model or fallback."""
     if not diff.strip():
-        return "✅ Nenhuma alteração de código para revisar."
+        return "✅ No code changes to review."
 
     system_prompt = generate_system_prompt(config)
 
-    # Determina qual modelo usar
+    # Determine which model to use
     preferred_model = os.environ.get("IARA_MODEL") or config.get("model", {}).get("preferred")
     fallback_enabled = config.get("model", {}).get("fallback_enabled", True)
 
@@ -86,31 +83,31 @@ def review_code(diff: str, api_key: str, config: dict) -> str:
             if m not in models_to_try:
                 models_to_try.append(m)
 
-    # Se IARA_MODEL via ENV estiver setado: usar APENAS esse modelo
+    # If IARA_MODEL env var is set: use ONLY that model
     env_model = os.environ.get("IARA_MODEL")
     if env_model:
         models_to_try = [env_model]
 
     errors = []
 
-    print(f"🔄 Iniciando revisão. Modelos na fila: {models_to_try}", file=sys.stderr)
+    print(f"🔄 Starting review. Model queue: {models_to_try}", file=sys.stderr)
 
     for model in models_to_try:
         try:
-            print(f"🔄 Tentando modelo: {model}...", file=sys.stderr)
+            print(f"🔄 Trying model: {model}...", file=sys.stderr)
             return review_code_with_model(diff, api_key, model, system_prompt)
         except (urllib.error.HTTPError, urllib.error.URLError) as e:
             error_msg = str(e)
-            print(f"⚠️ Falha de conexão/HTTP no modelo {model}: {error_msg}", file=sys.stderr)
+            print(f"⚠️ Connection/HTTP error on model {model}: {error_msg}", file=sys.stderr)
             errors.append(f"{model}: {error_msg}")
             time.sleep(1)
         except Exception as e:
             error_msg = str(e)
-            print(f"⚠️ Erro inesperado no modelo {model}: {error_msg}", file=sys.stderr)
+            print(f"⚠️ Unexpected error on model {model}: {error_msg}", file=sys.stderr)
             errors.append(f"{model}: {error_msg}")
             time.sleep(1)
 
             if env_model:
                 break
 
-    return f"❌ Não foi possível revisar com nenhum modelo disponível.\nErros:\n" + "\n".join(errors)
+    return f"❌ Could not review with any available model.\nErrors:\n" + "\n".join(errors)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,7 @@ class TestConfig(unittest.TestCase):
 
         config = load_config(self.config_path)
         self.assertEqual(config, DEFAULT_CONFIG)
-        self.assertEqual(config['project']['name'], "Projeto Genérico")
+        self.assertEqual(config['project']['name'], "Generic Project")
 
     def test_load_config_from_file(self):
         """Test loading configuration from a JSON file."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 from unittest.mock import patch, call
 
-from iara.init import run_init, _step_api_key, _step_project_config, _step_review_config, _mask_key
+from iara.init import run_init, _step_api_key, _step_project_config, _step_review_config, _step_language, _mask_key
 
 
 class TestMaskKey(unittest.TestCase):
@@ -15,6 +15,23 @@ class TestMaskKey(unittest.TestCase):
     def test_short_key(self):
         """Keys curtas retornam ***."""
         self.assertEqual(_mask_key("short"), "***")
+
+
+class TestStepLanguage(unittest.TestCase):
+    @patch("builtins.input", return_value="")
+    def test_default_en(self, mock_input):
+        """Default language is en."""
+        self.assertEqual(_step_language(), "en")
+
+    @patch("builtins.input", return_value="pt-br")
+    def test_custom_language(self, mock_input):
+        """Custom language code is accepted."""
+        self.assertEqual(_step_language(), "pt-br")
+
+    @patch("builtins.input", return_value="ES")
+    def test_uppercase_normalized(self, mock_input):
+        """Input is lowercased."""
+        self.assertEqual(_step_language(), "es")
 
 
 class TestStepProjectConfig(unittest.TestCase):
@@ -60,6 +77,7 @@ class TestRunInit(unittest.TestCase):
     @patch("iara.init.resolve_api_key", return_value=(None, "none"))
     @patch("getpass.getpass", return_value="sk-or-test-key")
     @patch("builtins.input", side_effect=[
+        "pt-br",            # language
         "Test Project",     # project name
         "Python",           # tech stack
         "A test project",   # description
@@ -79,6 +97,7 @@ class TestRunInit(unittest.TestCase):
         mock_save_config.assert_called_once()
         config_arg = mock_save_config.call_args[0][0]
         self.assertEqual(config_arg["project"]["name"], "Test Project")
+        self.assertEqual(config_arg["language"], "pt-br")
 
         # Verifica que save_global_config foi chamado com a key
         mock_save_global.assert_called_once_with({"api_key": "sk-or-test-key"})
@@ -88,6 +107,7 @@ class TestRunInit(unittest.TestCase):
     @patch("iara.init.resolve_api_key", return_value=("sk-or-existing", "config"))
     @patch("builtins.input", side_effect=[
         "Y",                # use existing key
+        "",                 # language (default en)
         "My Project",       # project name
         "",                 # tech stack (default)
         "",                 # description (default)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -7,8 +7,8 @@ class TestPrompt(unittest.TestCase):
         """Test that default config generates the generic prompt."""
         config = {
             "project": {
-                "name": "Projeto Genérico",
-                "description": "Um projeto de software.",
+                "name": "Generic Project",
+                "description": "A software project.",
                 "tech_stack": ["Python"]
             },
             "review": {
@@ -16,8 +16,9 @@ class TestPrompt(unittest.TestCase):
             }
         }
         prompt = generate_system_prompt(config)
-        self.assertIn("Projeto Genérico", prompt)
+        self.assertIn("Generic Project", prompt)
         self.assertIn("Python", prompt)
+        self.assertIn("English", prompt)
 
     def test_generate_prompt_unity(self):
         """Test that Unity config generates Unity-specific instructions."""
@@ -35,6 +36,44 @@ class TestPrompt(unittest.TestCase):
         self.assertIn("Unity", prompt)
         self.assertIn("C#", prompt)
         self.assertIn("mobile game", prompt)
+
+    def test_generate_prompt_language_ptbr(self):
+        """Test that pt-br language is injected into prompt."""
+        config = {
+            "project": {
+                "name": "Meu Projeto",
+                "description": "Um projeto.",
+                "tech_stack": ["Python"]
+            },
+            "language": "pt-br"
+        }
+        prompt = generate_system_prompt(config)
+        self.assertIn("Brazilian Portuguese", prompt)
+
+    def test_generate_prompt_language_default(self):
+        """Test that missing language defaults to English."""
+        config = {
+            "project": {
+                "name": "Test",
+                "description": "Test.",
+                "tech_stack": []
+            }
+        }
+        prompt = generate_system_prompt(config)
+        self.assertIn("English", prompt)
+
+    def test_generate_prompt_unknown_language(self):
+        """Test that unknown language code is used as-is."""
+        config = {
+            "project": {
+                "name": "Test",
+                "description": "Test.",
+                "tech_stack": []
+            },
+            "language": "swahili"
+        }
+        prompt = generate_system_prompt(config)
+        self.assertIn("swahili", prompt)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…st docs

- Add `language` config field (default: "en") to control review output language
- Rewrite system prompt (prompt.py) to English with dynamic language instruction
- Add LANGUAGE_MAP for 11 languages (en, pt-br, es, fr, de, it, ja, zh, ko, ru, pt)
- Add language selection step to `iara init` wizard (Step 2)
- Support IARA_LANGUAGE env var override in cli.py
- Add `language` input to GitHub Action (action.yml + entrypoint.sh)
- Translate all internal messages to English (reviewer.py, cli.py, config.py)
- Rewrite README.md in English (primary), create README.pt-br.md (Portuguese)
- Update iara-example.json with language field
- Add 6 new tests (language prompt injection, step_language, config defaults)
- 27 tests passing