### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/iara/__init__.py
+++ b/iara/__init__.py
@@ -1,6 +1,6 @@
 """Iara - AI Code Reviewer"""
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 
 from iara.config import load_config, DEFAULT_CONFIG
 from iara.prompt import generate_system_prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "iara-reviewer"
-version = "1.2.1"
+version = "1.3.0"
 description = "AI-powered code reviewer using OpenRouter LLMs"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps version from `1.2.1` to `1.3.0` in `pyproject.toml` and `iara/__init__.py`
- Multi-provider LLM support (OpenAI, Gemini, Anthropic, OpenRouter) warrants a minor version bump

## After merging
Create tag to trigger PyPI publish:
```bash
git checkout main && git pull
git tag -a v1.3.0 -m "v1.3.0" && git push origin v1.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)