### PR TITLE
fix: pass GitHub context variables to Docker action

### DIFF
--- a/.github/workflows/iara-review.yml
+++ b/.github/workflows/iara-review.yml
@@ -23,3 +23,5 @@ jobs:
           index_codebase: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}


### PR DESCRIPTION
## Summary

Fixes the "ERROR: REPO environment variable not set" that was preventing the Iara Code Review action from posting comments to PRs.

## Problem

When using Docker-based actions with remote images (`docker://ghcr.io/...`), GitHub context variables like `GITHUB_REPOSITORY` and `GITHUB_EVENT_PATH` are not automatically passed to the container.

The entrypoint.sh script expects these variables to:
- Identify the repository (`REPO="${GITHUB_REPOSITORY}"`)
- Determine the PR number (from `GITHUB_EVENT_PATH`)

## Solution

Added the required environment variables to the workflow step that calls the action:

```yaml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  GITHUB_REPOSITORY: ${{ github.repository }}
  GITHUB_EVENT_PATH: ${{ github.event_path }}
```

## Testing

This fix is required for PR #63 workflow to succeed. Once merged, we can re-run the failed workflow.

## Impact

- ✅ Fixes posting of PR review comments
- ✅ No breaking changes
- ✅ Required for all PRs going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)