### PR TITLE
fix: empty review comment (pass stdin arg to post_comment)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -165,10 +165,8 @@ if [ "$POST_COMMENT" = "true" ] && [ -n "$GITHUB_TOKEN" ]; then
   echo "Posting review comment to PR #${PR_NUMBER}..."
 
   # Use the new post_comment module which supports inline and summary modes
-  echo "$REVIEW" | PYTHONPATH=/app python3 -m iara.post_comment \
-    --token "$GITHUB_TOKEN" \
-    --repo "$REPO" \
-    --pr "$PR_NUMBER"
+  # Pass "-" to indicate reading from stdin (review text is piped via echo)
+  echo "$REVIEW" | PYTHONPATH=/app python3 -m iara.post_comment -
 
   if [ $? -eq 0 ]; then
     echo "Review posted successfully to PR #${PR_NUMBER}."


### PR DESCRIPTION
## Summary

Fixes the issue where Iara was posting empty review comments (only showing "--token").

## Problem

The entrypoint.sh was calling post_comment.py with arguments `--token`, `--repo`, `--pr`:

```bash
echo "$REVIEW" | python3 -m iara.post_comment \
  --token "$GITHUB_TOKEN" \
  --repo "$REPO" \
  --pr "$PR_NUMBER"
```

But `post_comment.py` doesn't accept these arguments. It only accepts:
- `-` to read from stdin
- `<review_text>` as first argument

When it saw `--token` as `sys.argv[1]`, it treated that as the review text instead of reading from stdin, resulting in comments showing only "--token".

## Solution

Added `-` as the first argument to explicitly indicate reading from stdin:

```bash
echo "$REVIEW" | python3 -m iara.post_comment -
```

The `post_comment.py` already reads `GITHUB_TOKEN`, `REPO`, and `PR_NUMBER` from environment variables, so passing them as arguments was unnecessary.

## Testing

This PR will trigger the Iara workflow which will test the fix and post a proper review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)