### PR TITLE
docs: restore clean README structure and remove duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,23 @@ Iara is an automated, project-agnostic, configurable code review tool designed t
 
 ---
 
+## Table of Contents
+
+- [Features](#-features)
+- [Capabilities](#-capabilities)
+- [Installation and Setup](#-installation-and-setup)
+- [How to Use](#-how-to-use)
+- [Documentation](#-documentation)
+- [Tests](#-tests)
+- [Contributing](#-contributing)
+- [License](#-license)
+
+---
+
 ## 🚀 Features
 
 - **Agnostic**: Configure your project context (Tech Stack, Rules) via JSON.
-- **Multi-Provider**: Connect directly to OpenRouter, OpenAI, Google Gemini, or Anthropic Claude.
+- **Multi-Provider**: Connect directly to OpenRouter, OpenAI, Google Gemini, Anthropic Claude, or Groq.
 - **Smart Fallback**: Automatically tries free models if the preferred one fails (OpenRouter only).
 - **Rules-Based (Static)**: Identifies dangerous patterns instantly without spending tokens (e.g., `GetComponent` in loops in Unity).
 - **LLM-Based (Intelligent)**: Uses AI to understand logic, security, and context, going beyond syntax.
@@ -69,7 +82,7 @@ iara init
 The wizard guides you through **5 steps**:
 
 1. **Language** — Choose the review output language (en, pt-br, es, fr, etc.)
-2. **Provider** — Choose your LLM provider: `openrouter` (default, free), `openai`, `gemini`, or `anthropic`
+2. **Provider** — Choose your LLM provider: `openrouter` (default, free), `openai`, `gemini`, `anthropic`, or `groq`
 3. **API Key** — Enter the key for the chosen provider (validated and saved to `~/.iara/config.json`)
 4. **Project** — Name, tech stack, description
 5. **Preferences** — Focus areas (Security, Performance, etc.)
@@ -107,10 +120,6 @@ export GEMINI_API_KEY="AIza..."
 # Anthropic Claude
 export IARA_PROVIDER="anthropic"
 export ANTHROPIC_API_KEY="sk-ant-..."
-
-# Groq
-export IARA_PROVIDER="groq"
-export GROQ_API_KEY="gsk_..."
 ```
 
 API key resolution priority: environment variable > global config (`~/.iara/config.json`).
@@ -122,194 +131,6 @@ git clone https://github.com/felipefernandes/iara.git
 cd iara
 pip install -e .
 ```
-
----
-
-## ⚙️ Project Configuration
-
-`iara init` automatically creates `.iara.json`. You can also create it manually:
-
-```json
-{
-  "project": {
-    "name": "My Project",
-    "description": "Project description.",
-    "tech_stack": ["Python"]
-  },
-  "review": {
-    "focus_areas": ["Performance", "Security"],
-    "ignore_patterns": ["fixtures", "migrations", "generated"],
-    "max_index_file_size": 10485760
-  },
-  "model": {
-    "preferred": "google/gemini-2.0-flash-exp:free",
-    "fallback_enabled": true,
-    "provider": "openrouter"
-  },
-  "language": "en"
-}
-```
-
-### `ignore_patterns` and `max_index_file_size`
-You can configure the Iara Indexer's footprint to respect maximum file limits and skip specific artifacts from the RAG context memory.
-
-**`max_index_file_size`:** Sets the byte threshold for a single file to be read (e.g. `10485760` for 10MB overrides the default 1MB restriction).
-**`ignore_patterns`:** Skips specific files or directories from being read (e.g., fixture folders or auto-generated payload files, which add zero value to code reviews). 
-
-**Important Notes on `ignore_patterns` behavior:**
-- 🛠️ **Merged with Defaults:** Your defined patterns are **added** to a default list (which already includes `.git`, `node_modules`, `venv`, `__pycache__`, etc.). You do not need to rewrite these.
-- ⚡ **Wildcards & Prefix Mathing:** Iara uses Python's `fnmatch`, which means patterns like `test` match exact files or folders named `test`. To act as prefixes or match extensions, use wildcards (e.g., `test*` to match `test_dir`, or `*_generated.*` to match files ending with that).
-- ⚠️ **Be Specific:** Broad patterns can inadvertently blind the Indexer. Using `*` or `*.py` as an ignore pattern will result in Iara ignoring your actual source code. It's safer to scope correctly (e.g., `tests/fixtures/*` or `logs/*.log`).
-
-### Supported providers and example models
-
-| Provider | `provider` value | Example models |
-| :--- | :--- | :--- |
-| OpenRouter (default) | `openrouter` | `google/gemini-2.0-flash-exp:free`, `meta-llama/llama-3.2-3b-instruct:free` |
-| OpenAI | `openai` | `gpt-4o`, `gpt-4.5-preview`, `o1` |
-| Google Gemini | `gemini` | `gemini-2.5-flash`, `gemini-2.5-pro` |
-| Anthropic Claude | `anthropic` | `claude-opus-4-5-20250929`, `claude-sonnet-4-5-20250929` |
-
-> **Note**: Smart fallback to free models is only available for OpenRouter. When using `openai`, `gemini`, or `anthropic`, set `"fallback_enabled": false`.
-
-The `language` field controls the review output language. Supported values: `en`, `pt-br`, `es`, `fr`, `de`, `ja`, `zh`, `ko`, `ru`, or any language the LLM understands.
-
-You can also override provider, model, and language via environment variables:
-
-```bash
-export IARA_PROVIDER="anthropic"
-export IARA_MODEL="claude-sonnet-4-5-20250929"
-export IARA_LANGUAGE="pt-br"
-```
-
-A ready-to-use example is available at `iara-example.json`.
-
----
-
-
-## 🧠 Memory (RAG) [New]
-
-Iara now supports a local **Retrieval-Augmented Generation (RAG)** system to provide context-aware reviews.
-
-### 1. Install Dependencies
-```bash
-pip install iara-reviewer[rag]
-# or
-pip install lancedb sentence-transformers torch numpy
-```
-
-### 2. Index Your Codebase
-Run this command in your project root to create the local vector index:
-```bash
-iara memory index
-```
-This will parse your code (extracting functions, classes, and calls) and store it in `.iara/data/lancedb`.
-
-#### Smart Chunking — Supported Languages
-
-Iara uses **language-aware chunking** to ensure that code blocks fed into the LLM represent complete logical units (functions, classes, methods) instead of arbitrary 100-line blocks:
-
-| Extension(s) | Strategy | What it extracts |
-| :--- | :--- | :--- |
-| `.py` | Python AST | Functions, async functions, classes |
-| `.js`, `.ts` | Regex + brace balancing | Functions, async functions, classes, arrow functions |
-| `.cs` | Regex + brace balancing | Classes, structs, interfaces, enums, methods |
-| All others | Plain-text fallback | Blocks of up to 100 lines |
-
-> **Why does this matter?** Chunks that cut a function in half generate noisy context for the LLM. Smart chunking keeps logical units intact, improving review accuracy and reducing token waste.
-
-### 3. Hybrid Search (Vector + Full-Text)
-
-Iara's memory system uses **hybrid search** combining two complementary search modes:
-
-| Search Mode | What it finds | Best for |
-| :--- | :--- | :--- |
-| **Vector Search** | Semantically similar code | Understanding context and logic |
-| **Full-Text Search (FTS)** | Exact symbol/name matching | Finding specific functions or variables |
-
-The system uses **Reciprocal Rank Fusion (RRF)** to intelligently merge both result sets:
-- Results appearing in both searches get boosted rankings
-- Symbol names match exactly (e.g., `calculate_risk_score()` finds `calculate_risk_score()`)
-- Semantic understanding complements lexical precision
-- Gracefully falls back to vector-only if FTS index unavailable
-
-**Result**: Better context retrieval for more accurate code reviews.
-
-### 4. Review with Context
-Just run the review command as usual. Iara will automatically use the memory to retrieve relevant context for the changed code.
-```bash
-git diff main | iara
-```
-
-### 5. Manage Memory
-To clear the index:
-```bash
-iara memory clear
-```
-
----
-
-## 💬 Inline PR Comments (Optional) [New]
-
-By default, Iara posts a single summary comment on your Pull Request. For a better developer experience, you can enable **inline comments** that are anchored directly to specific lines of code, similar to how CodeClimate, SonarCloud, or human reviewers comment.
-
-### Supported Platforms
-
-- ✅ **GitHub** — Uses [Pull Request Review Comments API](https://docs.github.com/en/rest/pulls/comments)
-- ✅ **GitLab** — Uses [Merge Request Discussions API](https://docs.gitlab.com/ee/api/discussions.html)
-
-### How to Enable
-
-Add a `ci` section to your `.iara.json` file:
-
-```json
-{
-  "ci": {
-    "platform": "github",
-    "review_mode": "inline"
-  },
-  "project": {
-    "name": "My Project",
-    "...": "..."
-  }
-}
-```
-
-**Configuration Options:**
-
-- **`platform`**: CI platform where Iara will post comments
-  - `"github"` — For GitHub Actions
-  - `"gitlab"` — For GitLab CI
-  - `null` or omitted — No platform specified (default behavior)
-
-- **`review_mode`**: How Iara posts review feedback
-  - `"summary"` — Single comment with all feedback (default)
-  - `"inline"` — Individual comments anchored to specific lines
-
-### Required Permissions
-
-#### GitHub Actions
-Your workflow needs `pull-requests: write` permission:
-
-```yaml
-permissions:
-  contents: read
-  pull-requests: write
-```
-
-#### GitLab CI
-The CI job token (`CI_JOB_TOKEN`) needs `api` scope, or use a personal access token with `api` permissions:
-
-```yaml
-variables:
-  GITLAB_TOKEN: ${CI_JOB_TOKEN}  # or use a PAT
-```
-
-### Behavior Notes
-
-- **Inline mode requires `platform` to be specified** — Setting `review_mode: inline` without `platform` will fail validation
-- **Graceful fallback** — If inline comment posting fails (e.g., JSON parsing error, API failure), Iara automatically falls back to summary mode
-- **Platform compatibility** — If your platform is not GitHub or GitLab, Iara defaults to summary mode with a warning
 
 ---
 
@@ -358,302 +179,28 @@ git diff | iara
 
 ---
 
-## 🐙 GitHub Integration
+## 📚 Documentation
 
-Iara is available on the [**GitHub Marketplace**](https://github.com/marketplace/actions/iara-code-reviewer) — you can add it to your repository with just a few clicks. No Docker required! Iara runs as a lightweight **Composite Action** directly on the runner, with automatic pip caching for fast execution.
+For detailed guides and configuration options, see:
 
-Add Iara to your GitHub repository in **2 steps**:
+- **[Configuration Guide](docs/configuration.md)** - Project configuration, providers, models, RAG memory setup
+- **[CI/CD Integration](docs/ci-integration.md)** - GitHub Actions, GitLab CI, Docker, inline PR comments
+- **[Contributing Guide](CONTRIBUTING.md)** - Development setup, testing, pull requests
 
-### 1. Configure the secret
+### Configuration Examples
 
-Go to **Settings > Secrets and variables > Actions > New repository secret** and add the key for your chosen provider:
+Complete configuration examples are available in [`examples/`](examples/):
 
-| Provider | Secret name |
-| :--- | :--- |
-| OpenRouter | `OPENROUTER_API_KEY` |
-| OpenAI | `OPENAI_API_KEY` |
-| Google Gemini | `GEMINI_API_KEY` |
-| Anthropic | `ANTHROPIC_API_KEY` |
+- [`examples/iara-example.json`](examples/iara-example.json) - Standard configuration
+- [`examples/iara-example-inline.json`](examples/iara-example-inline.json) - Inline PR comments mode
+- [`examples/github-workflow.yml`](examples/github-workflow.yml) - GitHub Actions workflow
+- [`examples/gitlab-ci.yml`](examples/gitlab-ci.yml) - GitLab CI pipeline
 
-### 2. Create the workflow
+### Quick Links
 
-Create the file `.github/workflows/iara-review.yml`.
-
-**With OpenRouter (default, free models):**
-
-```yaml
-name: Iara Code Review
-
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-permissions:
-  pull-requests: write
-  contents: read
-
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    name: AI Code Review
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run Iara Code Review
-        uses: felipefernandes/iara@main
-        with:
-          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-**With Anthropic Claude:**
-
-```yaml
-      - name: Run Iara Code Review
-        uses: felipefernandes/iara@main
-        with:
-          provider: anthropic
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-5-20250929"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-**With OpenAI:**
-
-```yaml
-      - name: Run Iara Code Review
-        uses: felipefernandes/iara@main
-        with:
-          provider: openai
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          model: "gpt-4o"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-**With Google Gemini:**
-
-```yaml
-      - name: Run Iara Code Review
-        uses: felipefernandes/iara@main
-        with:
-          provider: gemini
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          model: "gemini-2.5-flash"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-Iara will automatically:
-
-- Review the Pull Request diff
-- Post a comment with the review result
-
-### All available inputs
-
-```yaml
-- uses: felipefernandes/iara@main
-  with:
-    provider: "openrouter"                         # openrouter (default), openai, gemini, anthropic
-    openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}  # when provider=openrouter
-    openai_api_key: ${{ secrets.OPENAI_API_KEY }}          # when provider=openai
-    gemini_api_key: ${{ secrets.GEMINI_API_KEY }}          # when provider=gemini
-    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}    # when provider=anthropic
-    model: "google/gemini-2.0-flash-exp:free"     # override model
-    config_path: ".iara.json"                     # config path (default: .iara.json)
-    post_comment: "true"                           # post comment on PR (default: true)
-    language: "en"                                 # review language
-    index_codebase: "true"                         # enable RAG memory (default: false)
-```
-
----
-
-## 🦊 GitLab Integration
-
-### 1. Configure variables
-
-Go to **Settings > CI/CD > Variables** and add:
-
-- The key for your provider (e.g., `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
-- `IARA_PROVIDER`: the provider name (e.g., `anthropic`) — omit for OpenRouter default
-- `GITLAB_TOKEN`: Personal/Project Access Token with `api` scope (required for MR comments)
-
-### 2. Add to `.gitlab-ci.yml`
-
-**Using the pre-built Docker image (faster, recommended):**
-
-```yaml
-stages:
-  - review
-
-iara_code_review:
-  stage: review
-  image: ghcr.io/felipefernandes/iara:latest
-  script:
-    - git fetch origin $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
-    - export PR_DIFF=$(git diff origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME...$CI_COMMIT_SHA)
-    - REVIEW=$(iara 2>/tmp/iara_stderr.txt) || true
-    - echo "$REVIEW"
-    - |
-      if [ -n "$REVIEW" ] && [ -n "$GITLAB_TOKEN" ]; then
-        echo "$REVIEW" | python3 -m iara.post_comment \
-          --token "$GITLAB_TOKEN" \
-          --repo "$CI_PROJECT_PATH" \
-          --pr "$CI_MERGE_REQUEST_IID"
-      fi
-  allow_failure: true
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-```
-
-**Alternative: Using pip install (slower):**
-
-```yaml
-stages:
-  - review
-
-iara_code_review:
-  stage: review
-  image: python:3.11-slim
-  script:
-    - apt-get update && apt-get install -y --no-install-recommends git curl
-    - pip install iara-reviewer
-    - git fetch origin $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
-    - export PR_DIFF=$(git diff origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME...$CI_COMMIT_SHA)
-    - iara
-  allow_failure: true
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-```
-
-Iara will automatically:
-
-- Review the Merge Request diff
-- Post a comment with the review result on the MR
-
-A complete template is available at `gitlab-ci.yml`.
-
----
-
-## 🐳 Docker Image (Pre-built)
-
-Iara is available as a pre-built Docker image on **GitHub Container Registry (GHCR)**, which significantly speeds up CI/CD execution by eliminating dependency installation time.
-
-**Image:** `ghcr.io/felipefernandes/iara:latest`
-
-### Why use the Docker image?
-
-- ⚡ **Faster startup**: Skip `pip install` overhead — image pulls in seconds
-- 📦 **All dependencies included**: Python 3.11, RAG dependencies, git, curl, jq
-- 🔄 **Portable**: Works across GitHub Actions, GitLab CI, Jenkins, Bitbucket Pipelines, and more
-- 🔒 **Consistent environment**: Same runtime environment on every platform
-
-### Usage in GitHub Actions
-
-The GitHub Action (`felipefernandes/iara@main`) **already uses this Docker image** automatically. No additional configuration needed!
-
-If you want to use the Docker image directly:
-
-```yaml
-name: Iara Code Review
-
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-permissions:
-  pull-requests: write
-  contents: read
-
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/felipefernandes/iara:latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run Iara Review
-        run: |
-          export PR_DIFF=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3.diff" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}")
-          iara | python3 -m iara.post_comment \
-            --token "$GITHUB_TOKEN" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pr "${{ github.event.pull_request.number }}"
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-### Usage in GitLab CI
-
-```yaml
-stages:
-  - review
-
-iara_code_review:
-  stage: review
-  image: ghcr.io/felipefernandes/iara:latest
-  script:
-    - git fetch origin $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
-    - export PR_DIFF=$(git diff origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME...$CI_COMMIT_SHA)
-    - REVIEW=$(iara) || true
-    - echo "$REVIEW"
-    - echo "$REVIEW" | python3 -m iara.post_comment --token "$GITLAB_TOKEN" --repo "$CI_PROJECT_PATH" --pr "$CI_MERGE_REQUEST_IID"
-  only:
-    - merge_requests
-  variables:
-    OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
-    GITLAB_TOKEN: ${GITLAB_TOKEN}
-```
-
-### Usage in Jenkins, CircleCI, or Any Docker-enabled CI
-
-```bash
-docker run --rm \
-  -e OPENROUTER_API_KEY="sk-or-..." \
-  -e PR_DIFF="$(git diff main...HEAD)" \
-  ghcr.io/felipefernandes/iara:latest
-```
-
-### Local Testing
-
-You can test the Docker image locally before deploying to CI:
-
-```bash
-# Pull the image
-docker pull ghcr.io/felipefernandes/iara:latest
-
-# Run a review
-docker run --rm \
-  -e OPENROUTER_API_KEY="sk-or-..." \
-  -e PR_DIFF="$(git diff main)" \
-  ghcr.io/felipefernandes/iara:latest
-```
-
----
-
-## 🔧 Any CI (Jenkins, CircleCI, etc.)
-
-```bash
-pip install iara-reviewer
-
-# OpenRouter (default)
-export OPENROUTER_API_KEY="sk-or-..."
-git diff main...HEAD | iara
-
-# Anthropic Claude
-export IARA_PROVIDER="anthropic"
-export ANTHROPIC_API_KEY="sk-ant-..."
-export IARA_MODEL="claude-sonnet-4-5-20250929"
-git diff main...HEAD | iara
-```
+- [GitHub Marketplace](https://github.com/marketplace/actions/iara-code-reviewer) - Add Iara to your repository
+- [PyPI Package](https://pypi.org/project/iara-reviewer/) - Install via pip
+- [Changelog](CHANGELOG.md) - Version history and release notes
 
 ---
 
@@ -662,6 +209,20 @@ git diff main...HEAD | iara
 ```bash
 python -m unittest discover tests
 ```
+
+---
+
+## 🤝 Contributing
+
+We welcome contributions! See our [Contributing Guide](CONTRIBUTING.md) for:
+
+- Development setup
+- Running tests
+- Code quality standards
+- Pull request guidelines
+- Release process
+
+---
 
 ## 📜 License
 


### PR DESCRIPTION
## 📚 Problem

After PR #69 (Groq provider), the README was inflated from 229 to 668 lines due to duplicated content that should be in `docs/`.

## ✅ Solution

Restored the clean README structure from PR #63:
- **README.md**: 229 lines (landing page)
- Removed detailed configuration (→ `docs/configuration.md`)
- Removed CI integration details (→ `docs/ci-integration.md`)
- Added Groq to multi-provider mentions

## 📊 Impact

```diff
- README.md: 668 lines
+ README.md: 229 lines (-478 lines)
```

## 🔗 Related

- PR #63 (original docs reorganization)
- PR #69 (Groq provider - inflated README)
- Issue #62 (docs reorganization)